### PR TITLE
fix some import to support qt>=5

### DIFF
--- a/src/naoqi_dashboard/avahi.py
+++ b/src/naoqi_dashboard/avahi.py
@@ -33,7 +33,12 @@
 
 import dbus, gobject, dbus.glib
 
-from python_qt_binding.QtGui import QComboBox
+from distutils.version import LooseVersion
+import python_qt_binding
+if LooseVersion(python_qt_binding.QT_BINDING_VERSION).version[0] >= 5:
+    from python_qt_binding.QtWidgets import QComboBox
+else:
+    from python_qt_binding.QtGui import QComboBox
 
 import collections
 

--- a/src/naoqi_dashboard/frame.py
+++ b/src/naoqi_dashboard/frame.py
@@ -55,7 +55,12 @@ from rqt_robot_dashboard.dashboard import Dashboard
 from rqt_robot_dashboard.monitor_dash_widget import MonitorDashWidget
 from rqt_robot_dashboard.console_dash_widget import ConsoleDashWidget
 
-from PyQt4 import QtGui, QtCore
+from distutils.version import LooseVersion
+import python_qt_binding
+if LooseVersion(python_qt_binding.QT_BINDING_VERSION).version[0] >= 5:
+    from python_qt_binding.QtWidgets import QLabel
+else:
+    from PyQt4.QtGui import QLabel
 
 class NAOqiDashboard(Dashboard):
 
@@ -110,7 +115,7 @@ class NAOqiDashboard(Dashboard):
                  self._motors_button],
                 [self._power_state_ctrl],
                 #[self.posture_combobox, self.posture_button]
-                [QtGui.QLabel("Posture"), self._postures]
+                [QLabel("Posture"), self._postures]
                 ]
 
 

--- a/src/naoqi_dashboard/motors.py
+++ b/src/naoqi_dashboard/motors.py
@@ -34,7 +34,12 @@
 # Ported from pr2_motors: Vincent Rabaud, Aldebaran Robotics, 2014
 #
 
-from python_qt_binding.QtGui import QMessageBox
+from distutils.version import LooseVersion
+import python_qt_binding
+if LooseVersion(python_qt_binding.QT_BINDING_VERSION).version[0] >= 5:
+    from python_qt_binding.QtWidgets import QMessageBox
+else:
+    from python_qt_binding.QtGui import QMessageBox
 
 import actionlib
 import rospy

--- a/src/naoqi_dashboard/posture.py
+++ b/src/naoqi_dashboard/posture.py
@@ -34,7 +34,12 @@
 import actionlib
 import rospy
 
-from python_qt_binding.QtGui import QComboBox, QMessageBox
+from distutils.version import LooseVersion
+import python_qt_binding
+if LooseVersion(python_qt_binding.QT_BINDING_VERSION).version[0] >= 5:
+    from python_qt_binding.QtWidgets import QComboBox, QMessageBox
+else:
+    from python_qt_binding.QtGui import QComboBox, QMessageBox
 from naoqi_bridge_msgs.msg import BodyPoseWithSpeedAction, BodyPoseWithSpeedGoal
 
 class PostureWidget(QComboBox):


### PR DESCRIPTION
When we use ROS kinetic, qt5 is used instead of qt4 (indigo and before).
I fixed importing packages when we use qt5.

reference: https://github.com/jsk-ros-pkg/jsk_visualization/pull/708

This is an output when I executed `roslaunch naoqi_dashboard naoqi_dashboard.launch` before sending this pull-request:
My environment is Ubuntu 16.04, ROS kinetic, `naoqi_dashboard` from source.
```
kanae@kanae-ThinkPad-T440p:~/catkin_ws/src/naoqi_dashboard/src/naoqi_dashboard$ roslaunch naoqi_dashboard naoqi_dashboard.launch 
... logging to /home/kanae/.ros/log/c00486a2-de67-11e8-b155-28d244f02e4c/roslaunch-kanae-ThinkPad-T440p-21438.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://133.11.216.109:36645/

SUMMARY
========

CLEAR PARAMETERS
 * /naoqi_dashboard_aggregator/

PARAMETERS
 * /naoqi_dashboard_aggregator/analyzers/joystick/discard_stale: True
 * /naoqi_dashboard_aggregator/analyzers/joystick/find_and_remove_prefix: joy_node
 * /naoqi_dashboard_aggregator/analyzers/joystick/path: Joystick
 * /naoqi_dashboard_aggregator/analyzers/joystick/type: diagnostic_aggreg...
 * /naoqi_dashboard_aggregator/analyzers/naoqi/analyzers/Computer/find_and_remove_prefix: naoqi_driver_comp...
 * /naoqi_dashboard_aggregator/analyzers/naoqi/analyzers/Computer/path: Computer
 * /naoqi_dashboard_aggregator/analyzers/naoqi/analyzers/Computer/type: diagnostic_aggreg...
 * /naoqi_dashboard_aggregator/analyzers/naoqi/analyzers/Joints/find_and_remove_prefix: naoqi_driver_joints:
 * /naoqi_dashboard_aggregator/analyzers/naoqi/analyzers/Joints/path: Joints
 * /naoqi_dashboard_aggregator/analyzers/naoqi/analyzers/Joints/type: diagnostic_aggreg...
 * /naoqi_dashboard_aggregator/analyzers/naoqi/analyzers/PowerSystem/find_and_remove_prefix: naoqi_driver_batt...
 * /naoqi_dashboard_aggregator/analyzers/naoqi/analyzers/PowerSystem/path: Power System
 * /naoqi_dashboard_aggregator/analyzers/naoqi/analyzers/PowerSystem/type: diagnostic_aggreg...
 * /naoqi_dashboard_aggregator/analyzers/naoqi/path: NAOqi
 * /naoqi_dashboard_aggregator/analyzers/naoqi/type: diagnostic_aggreg...
 * /naoqi_dashboard_aggregator/analyzers/tf/find_and_remove_prefix: tf_monitor:
 * /naoqi_dashboard_aggregator/analyzers/tf/path: TF
 * /naoqi_dashboard_aggregator/analyzers/tf/type: diagnostic_aggreg...
 * /rosdistro: kinetic
 * /rosversion: 1.12.14

NODES
  /
    naoqi_dashboard (naoqi_dashboard/naoqi_dashboard)
    naoqi_dashboard_aggregator (diagnostic_aggregator/aggregator_node)
    tf_monitor (diagnostic_common_diagnostics/tf_monitor.py)

auto-starting new master
process[master]: started with pid [21448]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to c00486a2-de67-11e8-b155-28d244f02e4c
process[rosout-1]: started with pid [21461]
started core service [/rosout]
process[naoqi_dashboard-2]: started with pid [21479]
process[tf_monitor-3]: started with pid [21480]
process[naoqi_dashboard_aggregator-4]: started with pid [21481]
RosPluginProvider.load(naoqi_dashboard/NAOqiDashboard) exception raised in __builtin__.__import__(naoqi_dashboard.frame, [NAOqiDashboard]):
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_gui/ros_plugin_provider.py", line 80, in load
    module = __builtin__.__import__(attributes['module_name'], fromlist=[attributes['class_from_class_type']], level=0)
  File "/home/kanae/catkin_ws/devel/lib/python2.7/dist-packages/naoqi_dashboard/__init__.py", line 35, in <module>
    exec(__fh.read())
  File "<string>", line 1, in <module>
  File "/home/kanae/catkin_ws/src/naoqi_dashboard/src/naoqi_dashboard/frame.py", line 50, in <module>
    from .motors import Motors
  File "/home/kanae/catkin_ws/src/naoqi_dashboard/src/naoqi_dashboard/motors.py", line 37, in <module>
    from python_qt_binding.QtGui import QMessageBox
ImportError: cannot import name QMessageBox

PluginManager._load_plugin() could not load plugin "naoqi_dashboard/NAOqiDashboard":
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/qt_gui/plugin_handler.py", line 99, in load
    self._load()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/qt_gui/plugin_handler_direct.py", line 54, in _load
    self._plugin = self._plugin_provider.load(self._instance_id.plugin_id, self._context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py", line 71, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py", line 71, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_gui_py/ros_py_plugin_provider.py", line 60, in load
    return super(RosPyPluginProvider, self).load(plugin_id, plugin_context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py", line 71, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_gui/ros_plugin_provider.py", line 86, in load
    raise e
ImportError: cannot import name QMessageBox

================================================================================REQUIRED process [naoqi_dashboard-2] has died!
process has died [pid 21479, exit code 1, cmd /home/kanae/catkin_ws/src/naoqi_dashboard/scripts/naoqi_dashboard __name:=naoqi_dashboard __log:=/home/kanae/.ros/log/c00486a2-de67-11e8-b155-28d244f02e4c/naoqi_dashboard-2.log].
log file: /home/kanae/.ros/log/c00486a2-de67-11e8-b155-28d244f02e4c/naoqi_dashboard-2*.log
Initiating shutdown!
================================================================================
[naoqi_dashboard_aggregator-4] killing on exit
[tf_monitor-3] killing on exit
[naoqi_dashboard-2] killing on exit
[rosout-1] killing on exit
[master] killing on exit
shutting down processing monitor...
... shutting down processing monitor complete
done
```