### PR TITLE
fix ImportError: No module named gobject (for ROS kinetic, melodic)

### DIFF
--- a/src/naoqi_dashboard/avahi.py
+++ b/src/naoqi_dashboard/avahi.py
@@ -33,7 +33,12 @@
 
 import dbus, gobject, dbus.glib
 
-from python_qt_binding.QtGui import QComboBox
+from distutils.version import LooseVersion
+import python_qt_binding
+if LooseVersion(python_qt_binding.QT_BINDING_VERSION).version[0] >= 5:
+    from python_qt_binding.QtWidgets import QComboBox
+else:
+    from python_qt_binding.QtGui import QComboBox
 
 import collections
 

--- a/src/naoqi_dashboard/avahi.py
+++ b/src/naoqi_dashboard/avahi.py
@@ -31,7 +31,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import dbus, gobject, dbus.glib
+import dbus, dbus.glib
+from gi.repository import GObject as gobject
 
 from distutils.version import LooseVersion
 import python_qt_binding

--- a/src/naoqi_dashboard/frame.py
+++ b/src/naoqi_dashboard/frame.py
@@ -55,7 +55,12 @@ from rqt_robot_dashboard.dashboard import Dashboard
 from rqt_robot_dashboard.monitor_dash_widget import MonitorDashWidget
 from rqt_robot_dashboard.console_dash_widget import ConsoleDashWidget
 
-from PyQt4 import QtGui, QtCore
+from distutils.version import LooseVersion
+import python_qt_binding
+if LooseVersion(python_qt_binding.QT_BINDING_VERSION).version[0] >= 5:
+    from python_qt_binding.QtWidgets import QLabel
+else:
+    from PyQt4.QtGui import QLabel
 
 class NAOqiDashboard(Dashboard):
 
@@ -110,7 +115,7 @@ class NAOqiDashboard(Dashboard):
                  self._motors_button],
                 [self._power_state_ctrl],
                 #[self.posture_combobox, self.posture_button]
-                [QtGui.QLabel("Posture"), self._postures]
+                [QLabel("Posture"), self._postures]
                 ]
 
 

--- a/src/naoqi_dashboard/motors.py
+++ b/src/naoqi_dashboard/motors.py
@@ -34,7 +34,12 @@
 # Ported from pr2_motors: Vincent Rabaud, Aldebaran Robotics, 2014
 #
 
-from python_qt_binding.QtGui import QMessageBox
+from distutils.version import LooseVersion
+import python_qt_binding
+if LooseVersion(python_qt_binding.QT_BINDING_VERSION).version[0] >= 5:
+    from python_qt_binding.QtWidgets import QMessageBox
+else:
+    from python_qt_binding.QtGui import QMessageBox
 
 import actionlib
 import rospy

--- a/src/naoqi_dashboard/posture.py
+++ b/src/naoqi_dashboard/posture.py
@@ -34,7 +34,12 @@
 import actionlib
 import rospy
 
-from python_qt_binding.QtGui import QComboBox, QMessageBox
+from distutils.version import LooseVersion
+import python_qt_binding
+if LooseVersion(python_qt_binding.QT_BINDING_VERSION).version[0] >= 5:
+    from python_qt_binding.QtWidgets import QComboBox, QMessageBox
+else:
+    from python_qt_binding.QtGui import QComboBox, QMessageBox
 from naoqi_bridge_msgs.msg import BodyPoseWithSpeedAction, BodyPoseWithSpeedGoal
 
 class PostureWidget(QComboBox):


### PR DESCRIPTION
Related issue:  https://github.com/ros-naoqi/naoqi_dashboard/issues/5
(My environment is Ubuntu 18.04, ROS melodic, naoqi_dashboard from source (branch: [kochigami:modify-for-kinetic](https://github.com/kochigami/naoqi_dashboard/tree/modify-for-kinetic)))

Edit: I also confirmed this PR works in Ubuntu 16.04, ROS kinetic.

First, I searched for files which use `gobject` 
```
kochigami@kochigami-desktop:~/catkin_ws/src/naoqi_dashboard$ grep "gobject" -rl /home/kochigami/catkin_ws/src/naoqi_dashboard/
/home/kochigami/catkin_ws/src/naoqi_dashboard/src/naoqi_dashboard/avahi.pyc
/home/kochigami/catkin_ws/src/naoqi_dashboard/src/naoqi_dashboard/avahi.py
```
and then I modified `import gi` to `from gi.repository import GObject as gobject` in `avahi.py`.
I referenced this page: [Install gobject module?](https://stackoverflow.com/questions/37323567/install-gobject-module)


With this PR, I confirmed the error disappeared when doing `roslaunch naoqi_dashboard naoqi_dashboard.launch` .

Also, 

```
roslaunch pepper_bringup pepper_full.launch network_interface:=<My network interface>
roslaunch naoqi_dashboard naoqi_dashboard.launch 
```
made a NAOqi dashboard.